### PR TITLE
Add region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Collect AWS EC2 prices from AWS API to SQL table to analyze them.
 Make sure AWS credentials are set as environment variables or are available otherwise to `boto3` library
 which this program uses to connect to AWS API.
 
-The AWS Pricing API is [not available in all regions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints); this program defaults to connecting to the Pricing API endpoint in `us-east-1` (N. Virginia), and permits changing regions to the other available endpoints (`eu-central-1`, Frankfurt; `ap-south-1`, Mumbai) using the `--region` option.
+The AWS Price List Query API is [not available in all regions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints); this program defaults to using the API endpoint in `us-east-1` (N. Virginia), and permits changing regions to the other available endpoints (`eu-central-1`, Frankfurt; `ap-south-1`, Mumbai) using the `--region` option.
 
 ```shell
 Usage: ec2pricing [OPTIONS] COMMAND [ARGS]...

--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ Collect AWS EC2 prices from AWS API to SQL table to analyze them.
 Make sure AWS credentials are set as environment variables or are available otherwise to `boto3` library
 which this program uses to connect to AWS API.
 
+The AWS Pricing API is [not available in all regions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints); this program defaults to connecting to the Pricing API endpoint in `us-east-1` (N. Virginia), and permits changing regions to the other available endpoints (`eu-central-1`, Frankfurt; `ap-south-1`, Mumbai) using the `--region` option.
+
 ```shell
 Usage: ec2pricing [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --version  Show the version and exit.
+  -r, --region [us-east-1|eu-central-1|ap-south-1]
+             The AWS region to use. Limited to specific
+             regions where the Pricing API is available;
+             default: us-east-1  
   --help     Show this message and exit.
 
 Commands:

--- a/ec2pricing/main.py
+++ b/ec2pricing/main.py
@@ -105,7 +105,11 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 @click.version_option(version=__version__)
-def main():
+@click.option("-r", "--region", default="us-east-1", type=click.Choice(['us-east-1','eu-central-1','ap-south-1']), help="The AWS region to use. Limited to specific regions where the Pricing API is available; default: us-east-1")
+def main(region):
+    global _region 
+    
+    _region = region
     pass
 
 
@@ -336,7 +340,7 @@ def pricing():
     global _client
 
     if not _client:
-        _client = boto3.client("pricing")
+        _client = boto3.client("pricing", region_name=_region)
     return _client
 
 


### PR DESCRIPTION
The AWS Pricing API is [not available in all regions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints); this change defaults the tool to us-east-1 (N. Virginia), and permits changing regions to the other available endpoints (eu-central-1, Frankfurt; ap-south-1, Mumbai).